### PR TITLE
feat: disable body-max-line-length

### DIFF
--- a/.github/workflows/commit-lint.yaml
+++ b/.github/workflows/commit-lint.yaml
@@ -67,6 +67,7 @@ jobs:
             ],
             rules: {
               'header-max-length': [0],
+              'body-max-line-length': [0],
               'function-rules/header-max-length': [
                 2,
                 'always',


### PR DESCRIPTION
This rule was on by default but we do not want to enforce it.

JIRA: STL-550