### PR TITLE
fix(commit-lint): permit longer digest pin messages

### DIFF
--- a/.github/workflows/commit-lint.yaml
+++ b/.github/workflows/commit-lint.yaml
@@ -30,7 +30,7 @@ jobs:
           CONVENTIONAL_TYPES='build|chore|ci|docs|feat|fix|perf|refactor|revert|reapply|style|test'
           CONVENTIONAL_REGEX="^(${CONVENTIONAL_TYPES})(\(.+\))?!?: .+"
           # Bot-generated dep/version bumps (renovate, extimage, ...) - skip length and risk checks
-          BOT_BUMP_REGEX='^chore(\(deps\))?:[[:space:]]([Uu]pdate|bump)'
+          BOT_BUMP_REGEX='^chore(\(deps\))?:[[:space:]]([Uu]pdate|bump|pin)'
           # Repos that require a `risk:` trailer
           RISK_REPOS_REGEX='^(.*/)?(gdc-nas|gdc-ui|gooddata-ui-sdk|gdc-panther)$'
 


### PR DESCRIPTION
Renovate doesn't only [Uu]pdates or bumps, it also pins to given
version. For example:

```
chore(deps): pin 020413372491.dkr.ecr.us-east-1.amazonaws.com/pullthrough/docker.io/nginxinc/nginx-unprivileged docker tag to 37a4e0b
```

Co-Authored-By: 🧠
